### PR TITLE
Added optional metric parameter for raw data init

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ for(var k = 0; k < 500; k++) {
 var Y = tsne.getSolution(); // Y is an array of 2-D points that you can plot
 ```
 
-The data can be passed to tSNEJS as a set of high-dimensional points using the `tsne.initDataRaw(X)` function, where X is an array of arrays (high-dimensional points that need to be embedded). The algorithm computes the Gaussian kernel over these points and then finds the appropriate embedding.
+The data can be passed to tSNEJS as a set of high-dimensional points using the `tsne.initDataRaw(X)` function, where X is an array of arrays (high-dimensional points that need to be embedded). The algorithm computes the Gaussian kernel over these points and then finds the appropriate embedding. `initDataRaw` also accepts an optional `metric` input `tsne.initDataRaw(X, metric)` that will define a custom distance metric to use in place of the default of `L2`. Make sure the function you pass in takes two vectors as inputs and returns a single distance metric as a response.
 
 ## Web Demos
 There are two web interfaces to this library that we are aware of:

--- a/tsne.js
+++ b/tsne.js
@@ -83,13 +83,15 @@ var tsnejs = tsnejs || { REVISION: 'ALPHA' };
     return d;
   }
 
-  // compute pairwise distance in all vectors in X
-  var xtod = function(X) {
+  // compute pairwise distance in all vectors in X with optionally-configurable distance metric
+  var xtod = function(X, metric) {
+    // L2 stays the default distance metric
+    metric = metric || L2
     var N = X.length;
     var dist = zeros(N * N); // allocate contiguous array
     for(var i=0;i<N;i++) {
       for(var j=i+1;j<N;j++) {
-        var d = L2(X[i], X[j]);
+        var d = metric(X[i], X[j]);
         dist[i*N+j] = d;
         dist[j*N+i] = d;
       }
@@ -194,12 +196,13 @@ var tsnejs = tsnejs || { REVISION: 'ALPHA' };
 
     // this function takes a set of high-dimensional points
     // and creates matrix P from them using gaussian kernel
-    initDataRaw: function(X) {
+    initDataRaw: function(X, metric) {
       var N = X.length;
       var D = X[0].length;
       assert(N > 0, " X is empty? You must have some data!");
       assert(D > 0, " X[0] is empty? Where is the data?");
-      var dists = xtod(X); // convert X to distances using gaussian kernel
+      assert(typeof metric === "function" || !metric, "If your distance metric isn't a functon you might as well not have one!")
+      var dists = xtod(X, metric); // convert X to distances using gaussian kernel
       this.P = d2p(dists, this.perplexity, 1e-4); // attach to object
       this.N = N; // back up the size of the dataset
       this.initSolution(); // refresh this


### PR DESCRIPTION
@karpathy Small pull request that's really just some syntax sugar. Let's people pass in a function to the initDataRaw function that will serve as a replacement distance metric to L2. Technically already possible by just pre-computing the distances and passing those into the `initDataDist` function, but this makes it a bit nicer to use.

Hope this is useful functionality for others.
